### PR TITLE
fix: update Arrow schema for Arrow 58 compatibility

### DIFF
--- a/datafusion-loki/src/table.rs
+++ b/datafusion-loki/src/table.rs
@@ -14,15 +14,15 @@ use crate::{
 pub static TIMESTAMP_FIELD_REF: LazyLock<FieldRef> = LazyLock::new(|| {
     Arc::new(Field::new(
         "timestamp",
-        DataType::Timestamp(TimeUnit::Nanosecond, None),
+        DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
         false,
     ))
 });
 pub static LABELS_FIELD_REF: LazyLock<FieldRef> = LazyLock::new(|| {
-    let key_field = Field::new("keys", DataType::Utf8, false);
-    let value_field = Field::new("values", DataType::Utf8, true); // 值允许为空
+    let key_field = Field::new("key", DataType::Utf8, false);
+    let value_field = Field::new("value", DataType::Utf8, false);
     let entry_struct = DataType::Struct(vec![key_field, value_field].into());
-    let map_field = Arc::new(Field::new("entries", entry_struct, false));
+    let map_field = Arc::new(Field::new("key_value", entry_struct, false));
     Arc::new(Field::new("labels", DataType::Map(map_field, false), true))
 });
 pub static LINE_FIELD_REF: LazyLock<FieldRef> =

--- a/datafusion-loki/src/table.rs
+++ b/datafusion-loki/src/table.rs
@@ -14,7 +14,7 @@ use crate::{
 pub static TIMESTAMP_FIELD_REF: LazyLock<FieldRef> = LazyLock::new(|| {
     Arc::new(Field::new(
         "timestamp",
-        DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".into())),
+        DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
         false,
     ))
 });


### PR DESCRIPTION
## Summary

Fix two Arrow 58 schema incompatibility issues in `table.rs` that cause Flight serialization failures when querying Loki logs with timestamp/labels columns.

## Root Cause

datafusion-loki 0.5.0's static schema declarations in `table.rs` use Arrow 57 type conventions, which are incompatible with Arrow 58.

## Changes

### 1. Timestamp timezone (line 17)

Arrow 58's Parquet reader returns `Timestamp(Nanosecond, Some("UTC"))`, but the schema declares `Timestamp(Nanosecond, None)`. Flight serialization fails due to type mismatch.

```rust
// Before (Arrow 57)
DataType::Timestamp(TimeUnit::Nanosecond, None)
// After (Arrow 58)
DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))
```

### 2. Map field names (lines 22-25)

Arrow 58 changed Map internal field names from `entries/keys/values` to `key_value/key/value`.

```rust
// Before (Arrow 57)
Field::new("keys", ...), Field::new("values", ...), Field::new("entries", ...)
// After (Arrow 58)
Field::new("key", ...), Field::new("value", ...), Field::new("key_value", ...)
```

## Related

- Data-fabric 221 env: `SELECT * FROM loki_logs WHERE timestamp > ...` fails with `Timestamp(ns) vs Timestamp(ns, "UTC")` error