### PR TITLE
feat: enable chrono-tz feature on arrow dependency

### DIFF
--- a/datafusion-loki/Cargo.toml
+++ b/datafusion-loki/Cargo.toml
@@ -20,7 +20,7 @@ datafusion-functions = { workspace = true }
 datafusion-physical-expr = { workspace = true }
 datafusion-physical-plan = { workspace = true }
 datafusion-proto = { workspace = true }
-arrow = { workspace = true }
+arrow = { workspace = true, features = ["chrono-tz"] }
 parquet = { workspace = true, features = ["async"] }
 
 futures = "0.3"


### PR DESCRIPTION
## Summary

Add `chrono-tz` feature to the `arrow` dependency so that `Timestamp(ns, Some("UTC"))` works without runtime errors.

## Context

datafusion-loki declares its schema with `Timestamp(ns, Some("UTC"))` to match the Parquet reader output (Loki's documented Parquet format uses `TIMESTAMP WITH TIME ZONE`).

However, without the `chrono-tz` feature, Arrow cannot parse named timezone strings like `"UTC"` and throws `Invalid timezone "UTC": only offset based timezones supported without chrono-tz feature`.

## Change

```diff
-arrow = { workspace = true }
+arrow = { workspace = true, features = ["chrono-tz"] }
```